### PR TITLE
Update quick start guides from org.koin to io.insert-koin group ID

### DIFF
--- a/docs/quickstart/android-java.md
+++ b/docs/quickstart/android-java.md
@@ -21,7 +21,7 @@ repositories {
 }
 dependencies {
     // Koin for Android
-    compile "org.koin:koin-android:$koin_version"
+    compile "io.insert-koin:koin-android:$koin_version"
 }
 ```
 

--- a/docs/quickstart/android-viewmodel.md
+++ b/docs/quickstart/android-viewmodel.md
@@ -22,8 +22,8 @@ repositories {
 dependencies {
     // Koin for Android - Scope feature
     // include koin-android-scope & koin-android
-    implementation "org.koin:koin-android:$koin_version"
-    implementation "org.koin:koin-android-viewmodel:$koin_version"
+    implementation "io.insert-koin:koin-android:$koin_version"
+    implementation "io.insert-koin:koin-android-viewmodel:$koin_version"
 }
 ```
 

--- a/docs/quickstart/android.md
+++ b/docs/quickstart/android.md
@@ -21,7 +21,7 @@ repositories {
 }
 dependencies {
     // Koin for Android
-    compile "org.koin:koin-android:$koin_version"
+    compile "io.insert-koin:koin-android:$koin_version"
 }
 ```
 

--- a/docs/quickstart/junit-test.md
+++ b/docs/quickstart/junit-test.md
@@ -21,9 +21,9 @@ repositories {
 }
 dependencies {
     // Koin testing tools
-    testcompile "org.koin:koin-test:$koin_version"
+    testcompile "io.insert-koin:koin-test:$koin_version"
     // Needed JUnit version
-    testcompile "org.koin:koin-test-junit4:$koin_version"
+    testcompile "io.insert-koin:koin-test-junit4:$koin_version"
 }
 ```
 

--- a/docs/quickstart/kotlin.md
+++ b/docs/quickstart/kotlin.md
@@ -21,9 +21,9 @@ repositories {
 }
 dependencies {
     // Koin for Kotlin apps
-    compile "org.koin:koin-core:$koin_version"
+    compile "io.insert-koin:koin-core:$koin_version"
     // Testing
-    testCompile "org.koin:koin-test:$koin_version"
+    testCompile "io.insert-koin:koin-test:$koin_version"
 }
 ```
 

--- a/docs/quickstart/ktor.md
+++ b/docs/quickstart/ktor.md
@@ -33,7 +33,7 @@ repositories {
 }
 dependencies {
     // Koin for Kotlin apps
-    compile "org.koin:koin-ktor:$koin_version"
+    compile "io.insert-koin:koin-ktor:$koin_version"
 }
 ```
 


### PR DESCRIPTION
It looks like the documentation is not fully updated for the group ID change. I'm just getting started using Koin for the first time, and this one bit me.