### PR TITLE
Use printLogger in docs

### DIFF
--- a/docs/reference/koin-core/logging.md
+++ b/docs/reference/koin-core/logging.md
@@ -38,7 +38,7 @@ By default, By default Koin use the `EmptyLogger`. You can use directly the `Pri
 
 ```kotlin
 startKoin{
-    logger(LEVEL.INFO)
+    printLogger(LEVEL.INFO)
 }
 ```
 


### PR DESCRIPTION
Use a wrapper function call instead of `logger`. Probably the API changed and the docs were not updated. the old example does not work with a current version.